### PR TITLE
Fix segmentation fault when trying to read a file that doesn't exist.

### DIFF
--- a/Sources/File.swift
+++ b/Sources/File.swift
@@ -34,7 +34,9 @@ public class File {
   }
   
   deinit {
-    fclose(fileHandle)
+    if let fileHandle = self.fileHandle {
+	fclose(fileHandle)
+    }
   }
 
   /// Reads the file content and returns a string


### PR DESCRIPTION
```
do {
    try File.read(atPath: "foo")
} catch {
    print("I am sad.")                   
}   
```
Code snippet above was causing segmentation fault on archlinux. Checking if fileHandle is nil in deinit seems to fix the problem.